### PR TITLE
Improve rules editing GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Al guardar desde el editor integrado se crea autom\u00e1ticamente una copia `rul
 - Vista con landmarks superpuestos sobre la imagen de la cámara.
 - Nuevos tipos de macro: `open_app`, `write_text` y `move_cursor`.
 - Sonido de confirmación al ejecutar una acción.
+- Ventana gráfica para gestionar reglas sin editar YAML manualmente.

--- a/gesture2macro/rules.py
+++ b/gesture2macro/rules.py
@@ -38,3 +38,20 @@ def load_rules(path: str | Path) -> List[Rule]:
             )
         )
     return rules
+
+
+def save_rules(path: str | Path, rules: List[Rule]) -> None:
+    """Guarda la lista de reglas en formato YAML."""
+    data = []
+    for rule in rules:
+        macro_dict = {"type": rule.macro.type, **rule.macro.params}
+        data.append(
+            {
+                "name": rule.name,
+                "gesture": rule.gesture,
+                "macro": macro_dict,
+                "cooldown_ms": rule.cooldown_ms,
+            }
+        )
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh, allow_unicode=True, sort_keys=False)

--- a/gesture2macro/ui/main_window.py
+++ b/gesture2macro/ui/main_window.py
@@ -16,6 +16,7 @@ from ..macro_manager import execute_macro
 from ..rules import Rule, load_rules
 from ..utils.image_tools import to_rgb
 from .macro_editor import MacroEditor
+from .rule_manager import RuleManager
 from ..utils.logger import get_logger
 
 
@@ -70,9 +71,17 @@ class MainWindow(QtWidgets.QMainWindow):
         menu = self.menuBar().addMenu("Archivo")
         edit_rules = menu.addAction("Editar reglas...")
         edit_rules.triggered.connect(self.edit_rules)
+        edit_yaml = menu.addAction("Editar YAML...")
+        edit_yaml.triggered.connect(self.edit_yaml)
 
     # --------------------------------------------------------------- Actions ----
     def edit_rules(self) -> None:
+        dialog = RuleManager("rules.yaml", self)
+        if dialog.exec():
+            self.rules = load_rules("rules.yaml")
+            self.last_exec.clear()
+
+    def edit_yaml(self) -> None:
         dialog = MacroEditor("rules.yaml", self)
         if dialog.exec():
             self.rules = load_rules("rules.yaml")

--- a/gesture2macro/ui/rule_manager.py
+++ b/gesture2macro/ui/rule_manager.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from PySide6 import QtWidgets
+import yaml
+
+from ..rules import Rule, Macro, load_rules, save_rules
+
+
+class RuleEditorDialog(QtWidgets.QDialog):
+    """Dialogo simple para editar una regla."""
+
+    def __init__(self, rule: Rule | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Editar regla" if rule else "Nueva regla")
+        self._rule = rule
+
+        layout = QtWidgets.QFormLayout(self)
+
+        self.name_edit = QtWidgets.QLineEdit(self)
+        self.gesture_edit = QtWidgets.QLineEdit(self)
+        self.macro_combo = QtWidgets.QComboBox(self)
+        self.macro_combo.addItems(
+            [
+                "key_combo",
+                "scroll",
+                "click",
+                "open_app",
+                "write_text",
+                "move_cursor",
+            ]
+        )
+        self.params_edit = QtWidgets.QPlainTextEdit(self)
+        self.cooldown_spin = QtWidgets.QSpinBox(self)
+        self.cooldown_spin.setRange(0, 10000)
+
+        layout.addRow("Nombre", self.name_edit)
+        layout.addRow("Gesto", self.gesture_edit)
+        layout.addRow("Tipo de macro", self.macro_combo)
+        layout.addRow("Par\xC3\xA1metros YAML", self.params_edit)
+        layout.addRow("Cooldown ms", self.cooldown_spin)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
+            parent=self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+        if rule:
+            self.name_edit.setText(rule.name)
+            self.gesture_edit.setText(rule.gesture)
+            self.macro_combo.setCurrentText(rule.macro.type)
+            self.params_edit.setPlainText(
+                yaml.safe_dump(rule.macro.params, allow_unicode=True, sort_keys=False)
+            )
+            self.cooldown_spin.setValue(rule.cooldown_ms)
+
+    def get_rule(self) -> Rule:
+        params = yaml.safe_load(self.params_edit.toPlainText()) or {}
+        return Rule(
+            name=self.name_edit.text(),
+            gesture=self.gesture_edit.text(),
+            macro=Macro(type=self.macro_combo.currentText(), params=params),
+            cooldown_ms=self.cooldown_spin.value(),
+        )
+
+
+class RuleManager(QtWidgets.QDialog):
+    """Ventana para administrar reglas en forma de tabla."""
+
+    def __init__(self, path: str | Path, parent=None) -> None:
+        super().__init__(parent)
+        self.path = Path(path)
+        self.rules: List[Rule] = load_rules(self.path)
+        self.setWindowTitle("Reglas de gestos")
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.table = QtWidgets.QTableWidget(self)
+        self.table.setColumnCount(4)
+        self.table.setHorizontalHeaderLabels([
+            "Nombre",
+            "Gesto",
+            "Macro",
+            "Cooldown",
+        ])
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        layout.addWidget(self.table)
+
+        btns = QtWidgets.QHBoxLayout()
+        add_btn = QtWidgets.QPushButton("Agregar", self)
+        edit_btn = QtWidgets.QPushButton("Editar", self)
+        del_btn = QtWidgets.QPushButton("Eliminar", self)
+        btns.addWidget(add_btn)
+        btns.addWidget(edit_btn)
+        btns.addWidget(del_btn)
+        layout.addLayout(btns)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Save | QtWidgets.QDialogButtonBox.Cancel,
+            parent=self,
+        )
+        layout.addWidget(buttons)
+
+        add_btn.clicked.connect(self.add_rule)
+        edit_btn.clicked.connect(self.edit_rule)
+        del_btn.clicked.connect(self.del_rule)
+        buttons.accepted.connect(self.save)
+        buttons.rejected.connect(self.reject)
+
+        self.refresh()
+
+    # ----------------------------------------------------------------- actions
+    def refresh(self) -> None:
+        self.table.setRowCount(len(self.rules))
+        for row, rule in enumerate(self.rules):
+            self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(rule.name))
+            self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(rule.gesture))
+            self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(rule.macro.type))
+            self.table.setItem(row, 3, QtWidgets.QTableWidgetItem(str(rule.cooldown_ms)))
+        self.table.resizeColumnsToContents()
+
+    def _selected_row(self) -> int:
+        items = self.table.selectionModel().selectedRows()
+        return items[0].row() if items else -1
+
+    def add_rule(self) -> None:
+        dialog = RuleEditorDialog(parent=self)
+        if dialog.exec() == QtWidgets.QDialog.Accepted:
+            self.rules.append(dialog.get_rule())
+            self.refresh()
+
+    def edit_rule(self) -> None:
+        idx = self._selected_row()
+        if idx < 0:
+            return
+        dialog = RuleEditorDialog(self.rules[idx], parent=self)
+        if dialog.exec() == QtWidgets.QDialog.Accepted:
+            self.rules[idx] = dialog.get_rule()
+            self.refresh()
+
+    def del_rule(self) -> None:
+        idx = self._selected_row()
+        if idx >= 0:
+            self.rules.pop(idx)
+            self.refresh()
+
+    def save(self) -> None:
+        save_rules(self.path, self.rules)
+        self.accept()


### PR DESCRIPTION
## Summary
- add `RuleManager` dialog to handle rules with a table UI
- integrate the new dialog into the main window and keep YAML editor as advanced option
- allow saving rule lists to YAML
- mention the new interface in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685743831738832ab97780808d5f96b0