### PR TITLE
Add Windows packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ Al guardar desde el editor integrado se crea autom\u00e1ticamente una copia `rul
 - Nuevos tipos de macro: `open_app`, `write_text` y `move_cursor`.
 - Sonido de confirmación al ejecutar una acción.
 - Ventana gráfica para gestionar reglas sin editar YAML manualmente.
+
+### Ejecutable para Windows
+
+El repositorio incluye el script `build_windows_exe.bat` que genera un ejecutable
+lista para usar en Windows. Basta con ejecutar el archivo desde la consola de
+Windows y se creará `dist/Gesture2Macro.exe` usando PyInstaller.

--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -1,0 +1,8 @@
+@echo off
+REM Empaqueta Gesture2Macro como ejecutable usando PyInstaller
+python -m pip install -r requirements.txt
+pyinstaller --noconsole --onefile -n Gesture2Macro gesture2macro\__main__.py
+echo.
+echo El ejecutable se encuentra en dist\Gesture2Macro.exe
+pause
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PySide6==6.6.1
 PyYAML==6.0.1
 pyautogui==0.9.54
 watchdog==3.0.0
+pyinstaller==6.14.1


### PR DESCRIPTION
## Summary
- add script `build_windows_exe.bat` for generating a Windows executable
- include PyInstaller in requirements
- document new script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68633be7b45c832aaf0db348233dc3f8