### PR TITLE
Fix exe crash due to relative import

### DIFF
--- a/gesture2macro/__main__.py
+++ b/gesture2macro/__main__.py
@@ -1,4 +1,10 @@
-from .main import main
+"""Entry point for both package and frozen execution."""
+
+# When running the module as a script (e.g. the PyInstaller generated
+# executable) ``__package__`` is ``None`` and relative imports fail.  Using an
+# absolute import works in both scenarios: ``python -m gesture2macro`` and the
+# bundled executable.
+from gesture2macro.main import main
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- handle frozen execution by switching to absolute import in `__main__`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863524e5bcc832aa5d055f9b5a33969